### PR TITLE
GH-2: Do not set upstream when pushing to remote branch.

### DIFF
--- a/src/command/push.ts
+++ b/src/command/push.ts
@@ -32,10 +32,6 @@ export async function push(repositoryPath: string, remote: string, localBranch: 
         remoteBranch ? `${localBranch}:${remoteBranch}` : localBranch,
     ];
 
-    if (!remoteBranch) {
-        args.push('--set-upstream');
-    }
-
     let opts: IGitExecutionOptions = {};
 
     if (progressCallback) {


### PR DESCRIPTION
So that we never modify the Git configuration as a side-effect.

Closes #2.

Signed-off-by: "Akos Kitta" <"kittaakos@gmail.com">